### PR TITLE
Support for Qt5Agg backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.ini
 !requirements.txt
 !pytest.ini
-test*.py
+test.py
 opensurfacesim/decoders/mwpm/blossom5-v2.05.src/
 
 .python-version

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install opensurfacesim
 ## Requirements
 
 * Python 3.7+
-* Tkinter for interactive plotting. Your Python distribution may or may not bundled Tkinter already. Check out this [guide](https://realpython.com/python-gui-tkinter/)  from realpython.com to install Tkinter if you encounter any problems.
+* [Tkinter](https://docs.python.org/3/library/tkinter.html) or [PyQt5](https://riverbankcomputing.com/software/pyqt/intro) for interactive plotting.
 * Matplotlib 3.4+ for plotting on a 3D lattice (Refers to a future release of matplotlib, see [pull request](https://github.com/matplotlib/matplotlib/pull/18816))
 
 ### MWPM decoder
@@ -77,6 +77,8 @@ Benchmarking of decoders can be enabled by attaching a *benchmarker* object to t
 'std': 0.002170364089572033}}}}
 ```
 
+## Plotting
+
 The figures in opensurfacesim allows for step-by-step visualization of the surface code simulation (and if supported the decoding process). Each figure logs its history such that the user can move backwards in time to view past states of the surface (and decoder). Press `h` when the figure is open for more information.
 
 ```python
@@ -95,6 +97,10 @@ Plotting will be performed on a 3D axis if faulty measurements are enabled.
 ```
 
 ![Interactive plotting on a toric code with faulty measurements.](https://raw.githubusercontent.com/watermarkhu/OpenSurfaceSim/master/images/toric-3d.gif "Iteractive plotting on a 3d axis")
+
+In IPython, inline images are created for each iteration of the plot, which can be tested in the [example notebook](https://mybinder.org/v2/gh/watermarkhu/opensurfacesim/master?filepath=examples.ipynb).
+
+## CLI
 
 Simulations can also be initiated from the command line
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath("../../"))
 
 # -- Project information -----------------------------------------------------
@@ -37,9 +38,9 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
+    "python": ("https://docs.python.org/3", None),
     "matplotlib": ("https://matplotlib.org/", None),
-    "networkx": ("https://networkx.github.io/documentation/stable/", None), 
+    "networkx": ("https://networkx.github.io/documentation/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/opensurfacesim/codes/_template/plot.py
+++ b/opensurfacesim/codes/_template/plot.py
@@ -152,7 +152,6 @@ class PerfectMeasurements(TemplateSimPM):
 
             self._plot_surface()
 
-
         def init_legend(self, legend_items: List[Line2D] = [], **kwargs):
             """Initializes the legend of the main axis of the figure. Also takes keyword arguments for `~matplotlib.axes.Axes.legend`.
 
@@ -390,20 +389,21 @@ class PerfectMeasurements(TemplateSimPM):
 class FaultyMeasurements(PerfectMeasurements, TemplateSimFM):
     """Plotting template code class for faulty measurements.
 
-    Inherits from `.codes._template.sim.FaultyMeasurements` and `.codes._template.plot.PerfectMeasurements`. See documentation for these classes for more. 
+    Inherits from `.codes._template.sim.FaultyMeasurements` and `.codes._template.plot.PerfectMeasurements`. See documentation for these classes for more.
 
-    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes._template.plot.PerfectMeasurements.Figure`, or the 2D `.codes._template.plot.PerfectMeasurements.Figure` is used. 
+    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes._template.plot.PerfectMeasurements.Figure`, or the 2D `.codes._template.plot.PerfectMeasurements.Figure` is used.
 
     Parameters
     ----------
     args
-        Positional arguments are passed on to `.codes._template.sim.FaultyMeasurements`. 
+        Positional arguments are passed on to `.codes._template.sim.FaultyMeasurements`.
     figure3d
         Enables plotting on a 3D lattice. Disable to plot layer-by-layer on a 2D lattice, which increases responsiveness.
     kwargs
-        Keyword arguments are passed on to `.codes._template.sim.FaultyMeasurements` and the figure object. 
-    
+        Keyword arguments are passed on to `.codes._template.sim.FaultyMeasurements` and the figure object.
+
     """
+
     def __init__(self, *args, figure3d: bool = True, **kwargs) -> None:
         self.figure3d = figure3d
         TemplateSimFM.__init__(self, *args, **kwargs)

--- a/opensurfacesim/codes/_template/sim.py
+++ b/opensurfacesim/codes/_template/sim.py
@@ -161,9 +161,7 @@ class PerfectMeasurements(ABC):
         """
         for error_module in error_modules:
             if type(error_module) == str:
-                error_module = importlib.import_module(
-                    ".errors.{}".format(error_module), package="opensurfacesim"
-                )
+                error_module = importlib.import_module(".errors.{}".format(error_module), package="opensurfacesim")
             self._init_error(error_module, error_rates)
 
     def _init_error(self, error_module, error_rates):
@@ -185,19 +183,15 @@ class PerfectMeasurements(ABC):
         **kwargs,
     ) -> DataQubit:
         """Initializes a `~.codes.elements.DataQubit` and saved to ``self.data_qubits[z][loc]``.
-        
+
         Parameters
         ----------
         initial_states
-            Initial state for the data-qubit. 
+            Initial state for the data-qubit.
         """
         data_qubit = self._DataQubit(loc, z, **kwargs)
-        data_qubit.edges["x"] = self._Edge(
-            data_qubit, "x", initial_state=initial_states[0], **kwargs
-        )
-        data_qubit.edges["z"] = self._Edge(
-            data_qubit, "z", initial_state=initial_states[1], **kwargs
-        )
+        data_qubit.edges["x"] = self._Edge(data_qubit, "x", initial_state=initial_states[0], **kwargs)
+        data_qubit.edges["z"] = self._Edge(data_qubit, "z", initial_state=initial_states[1], **kwargs)
         self.data_qubits[z][loc] = data_qubit
         return data_qubit
 
@@ -257,9 +251,7 @@ class PerfectMeasurements(ABC):
     ----------------------------------------------------------------------------------------
     """
 
-    def random_errors(
-        self, apply_order: Optional[List[str]] = None, measure: bool = True, **kwargs
-    ):
+    def random_errors(self, apply_order: Optional[List[str]] = None, measure: bool = True, **kwargs):
         """Applies all errors loaded in ``self.errors`` attribute to layer ``z``.
 
         The random error is applied for each loaded error module by calling `~.errors._template.Sim.random_error`. If ``apply_order`` is specified, the error modules are applied in order of the error names in the list. If no order is specified, the errors are applied in a random order. Addionally, any error rate can set by supplying the rate as a keyword argument e.g. ``p_bitflip = 0.1``.
@@ -269,13 +261,11 @@ class PerfectMeasurements(ABC):
         apply_order
             The order in which the error modules are applied. Items in the list must equal keys in ``self.errors`` or the names of the loaded error modules.
         measure
-            Measure ancilla qubits after errors have been simulated. 
+            Measure ancilla qubits after errors have been simulated.
 
         """
         self.instance = time.time()
-        ordered_errors = (
-            [self.errors[name] for name in apply_order] if apply_order else self.errors.values()
-        )
+        ordered_errors = [self.errors[name] for name in apply_order] if apply_order else self.errors.values()
         for error_class in ordered_errors:
             for qubit in self.data_qubits[self.layer].values():
                 error_class.random_error(qubit, **kwargs)
@@ -304,7 +294,7 @@ class FaultyMeasurements(PerfectMeasurements):
     p_bitflip_plaq
         Default bitflip rate during measurements on plaquette operators (XXXX).
     p_bitflip_star
-        Default bitflip rate during measurements on star operators (ZZZZ). 
+        Default bitflip rate during measurements on star operators (ZZZZ).
     """
 
     _PseudoEdge = PseudoEdge

--- a/opensurfacesim/codes/planar/plot.py
+++ b/opensurfacesim/codes/planar/plot.py
@@ -16,18 +16,18 @@ class PerfectMeasurements(SimPM, TemplatePM):
 class FaultyMeasurements(SimFM, TemplateFM):
     """Plotting code class for faulty measurements.
 
-    Inherits from `.codes.planar.sim.FaultyMeasurements` and `.codes.planar.plot.PerfectMeasurements`. See documentation for these classes for more. 
+    Inherits from `.codes.planar.sim.FaultyMeasurements` and `.codes.planar.plot.PerfectMeasurements`. See documentation for these classes for more.
 
-    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes.planar.plot.PerfectMeasurements.Figure`, or the 2D `.codes.planar.plot.PerfectMeasurements.Figure` is used. 
+    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes.planar.plot.PerfectMeasurements.Figure`, or the 2D `.codes.planar.plot.PerfectMeasurements.Figure` is used.
 
     Parameters
     ----------
     args
-        Positional arguments are passed on to `.codes.planar.sim.FaultyMeasurements`. 
+        Positional arguments are passed on to `.codes.planar.sim.FaultyMeasurements`.
     figure3d
         Enables plotting on a 3D lattice. Disable to plot layer-by-layer on a 2D lattice, which increases responsiveness.
     kwargs
-        Keyword arguments are passed on to `.codes.planar.sim.FaultyMeasurements` and the figure object. 
+        Keyword arguments are passed on to `.codes.planar.sim.FaultyMeasurements` and the figure object.
     """
 
     class Figure2D(PerfectMeasurements.Figure, TemplateFM.Figure2D):

--- a/opensurfacesim/codes/toric/plot.py
+++ b/opensurfacesim/codes/toric/plot.py
@@ -16,20 +16,21 @@ class PerfectMeasurements(SimPM, PlotPM):
 class FaultyMeasurements(SimFM, PlotFM):
     """Plotting code class for faulty measurements.
 
-    Inherits from `.codes.toric.sim.FaultyMeasurements` and `.codes.toric.plot.PerfectMeasurements`. See documentation for these classes for more. 
+    Inherits from `.codes.toric.sim.FaultyMeasurements` and `.codes.toric.plot.PerfectMeasurements`. See documentation for these classes for more.
 
-    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes.toric.plot.PerfectMeasurements.Figure`, or the 2D `.codes.toric.plot.PerfectMeasurements.Figure` is used. 
+    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes.toric.plot.PerfectMeasurements.Figure`, or the 2D `.codes.toric.plot.PerfectMeasurements.Figure` is used.
 
     Parameters
     ----------
     args
-        Positional arguments are passed on to `.codes.toric.sim.FaultyMeasurements`. 
+        Positional arguments are passed on to `.codes.toric.sim.FaultyMeasurements`.
     figure3d
         Enables plotting on a 3D lattice. Disable to plot layer-by-layer on a 2D lattice, which increases responsiveness.
     kwargs
-        Keyword arguments are passed on to `.codes.toric.sim.FaultyMeasurements` and the figure object. 
-    
+        Keyword arguments are passed on to `.codes.toric.sim.FaultyMeasurements` and the figure object.
+
     """
+
     class Figure2D(PerfectMeasurements.Figure, PlotFM.Figure2D):
         # Inherited docstring
         pass

--- a/opensurfacesim/decoders/_template.py
+++ b/opensurfacesim/decoders/_template.py
@@ -273,21 +273,21 @@ class Sim(ABC):
 class Plot(Sim):
     """Decoder plotting class template.
 
-    The plotting decoder class requires a surface code object that inherits from `.codes._template.plot.PerfectMeasurements`. The template decoder provides the `plot_matching_edge` method that is called by `correct_edge` to visualize the matched edges on the lattice. 
+    The plotting decoder class requires a surface code object that inherits from `.codes._template.plot.PerfectMeasurements`. The template decoder provides the `plot_matching_edge` method that is called by `correct_edge` to visualize the matched edges on the lattice.
 
     parameters
     ----------
     args, kwargs
-        Positional and keyword arguments are passed on to `~.decoders._template.Sim`. 
+        Positional and keyword arguments are passed on to `~.decoders._template.Sim`.
 
     attributes
     ----------
     line_color_match : dict
-        Plot properties for matched edges. 
+        Plot properties for matched edges.
     line_color_normal : dict
-        Plot properties for normal edges. 
+        Plot properties for normal edges.
     matching_lines : defaultdict(bool)
-        Dictionary of edges that have been added to the matching. 
+        Dictionary of edges that have been added to the matching.
     """
 
     name = ("Template plot decoder",)

--- a/opensurfacesim/decoders/mwpm/__init__.py
+++ b/opensurfacesim/decoders/mwpm/__init__.py
@@ -18,7 +18,7 @@ blossom5_dir = "blossom5-v2.05.src"
 
 def get_blossomv(accept: bool = False):
     """Downloads and compiles the BlossomV algorithm, which is distributed under the following license:
-    
+
     License:
 
     .. include:: ../../../opensurfacesim/decoders/mwpm/blossom5/LICENSE
@@ -29,7 +29,7 @@ def get_blossomv(accept: bool = False):
 
     try:
         with open(folder + "/blossom5/LICENSE", "r") as licensefile:
-            lines = "_"*49
+            lines = "_" * 49
             print(f"The Blossom V algorithm is distributed under a different license:\n{lines}\n")
             print(licensefile.read(), end=f"{lines}\n")
     except FileNotFoundError:

--- a/opensurfacesim/decoders/mwpm/plot.py
+++ b/opensurfacesim/decoders/mwpm/plot.py
@@ -4,21 +4,23 @@ from .._template import Plot
 
 class Toric(Plot, SimToric):
     """Plot MWPM decoder for the toric code.
-    
+
     Parameters
     ----------
     args, kwargs
-        Positional and keyword arguments are passed on to `.decoders._template.Plot` and `.decoders.mwpm.sim.Toric`. 
+        Positional and keyword arguments are passed on to `.decoders._template.Plot` and `.decoders.mwpm.sim.Toric`.
     """
+
     pass
 
 
 class Planar(Toric, SimPlanar):
     """Plot MWPM decoder for the planar code.
-    
+
     Parameters
     ----------
     args, kwargs
-        Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric` and `.decoders.mwpm.sim.Planar`. 
+        Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric` and `.decoders.mwpm.sim.Planar`.
     """
+
     pass

--- a/opensurfacesim/decoders/mwpm/sim.py
+++ b/opensurfacesim/decoders/mwpm/sim.py
@@ -12,11 +12,11 @@ LA = List[AncillaQubit]
 
 class Toric(Sim):
     """Minimum-Weight Perfect Matching decoder for the toric lattice.
-    
+
     Parameters
     ----------
     args, kwargs
-        Positional and keyword arguments are passed on to `.decoders._template.Sim`. 
+        Positional and keyword arguments are passed on to `.decoders._template.Sim`.
     """
 
     name = "Minimum-Weight Perfect Matching"

--- a/opensurfacesim/decoders/ufns/elements.py
+++ b/opensurfacesim/decoders/ufns/elements.py
@@ -157,15 +157,16 @@ class OddNode(Node):
 def print_tree(current_node: Node, parent_node: Optional[Node] = None):
     """Prints the node-tree of ``current_node`` and its descendents.
 
-    Utilizes `pptree <https://pypi.org/project/pptree/>`_ to print a tree of nodes, which requires a list of children elements per node. Since the node-tree is semi-directional (the root can be any element in the tree), we need to traverse the node-tree from ``current_node`` in all directions except for the ``parent_node`` to find the children attributes for the current direction.  
+    Utilizes `pptree <https://pypi.org/project/pptree/>`_ to print a tree of nodes, which requires a list of children elements per node. Since the node-tree is semi-directional (the root can be any element in the tree), we need to traverse the node-tree from ``current_node`` in all directions except for the ``parent_node`` to find the children attributes for the current direction.
 
     Parameters
     ----------
     current_node
-        Current root of the node-tree to print. 
+        Current root of the node-tree to print.
     parent_node
         Parent node which will not be printed. s
     """
+
     def get_children(node, parent=None):
         node.children = [child for child, _ in node.neighbors if child is not parent]
         for child in node.children:

--- a/opensurfacesim/decoders/unionfind/plot.py
+++ b/opensurfacesim/decoders/unionfind/plot.py
@@ -131,8 +131,9 @@ class Toric(SimToric, Plot):
         Parameters
         ----------
         args, kwargs
-            Positional and keyword arguments are forwarded to `.plot.Template2D`. 
+            Positional and keyword arguments are forwarded to `.plot.Template2D`.
         """
+
         def __init__(self, decoder, name, *args, **kwargs) -> None:
             self.decoder = decoder
             self.code = decoder.code
@@ -141,8 +142,6 @@ class Toric(SimToric, Plot):
             self.colors1 = {"x": self.params.color_x_primary, "z": self.params.color_z_primary}
             self.colors2 = {"x": self.params.color_x_secondary, "z": self.params.color_z_secondary}
 
-        def init_plot(self, **kwargs):
-            # Inherited docstring
             size = [xy + 0.25 for xy in self.code.size]
             self._init_axis([-0.25, -0.25] + size, title=self.decoder, aspect="equal")
 
@@ -181,7 +180,7 @@ class Toric(SimToric, Plot):
                 ),
             ]
             labels = [artist.get_label() if hasattr(artist, "get_label") else artist[0].get_label() for artist in handles]
-            self.legend_ax.legend(handles, labels, **kwargs)
+            self.legend_ax.legend(handles, labels, **kwargs.pop("uf_legend_kwargs", {}))
 
         def _plot_half_edge(
             self,
@@ -219,12 +218,12 @@ class Toric(SimToric, Plot):
                 for artist in edge.uf_plot.values():
                     self.new_properties(artist, {"visible": False})
 
-        def _match_edge(self, edge:Edge):
+        def _match_edge(self, edge: Edge):
             """Updates the color of an matched edge."""
             for artist in edge.uf_plot.values():
                 self.new_properties(artist, {"color": self.colors1[edge.state_type]})
 
-        def _plot_ancilla(self, ancilla:AncillaQubit, init:bool=False):
+        def _plot_ancilla(self, ancilla: AncillaQubit, init: bool = False):
             """Adds a syndrome to the plot."""
 
             rotations = {"x": 0, "z": 45}
@@ -286,8 +285,9 @@ class Toric(SimToric, Plot):
         Parameters
         ----------
         args, kwargs
-            Positional and keyword arguments are forwarded to `~.decoders.unionfind.plot.Toric.Figure2D` and `.plot.Template3D`. 
+            Positional and keyword arguments are forwarded to `~.decoders.unionfind.plot.Toric.Figure2D` and `.plot.Template3D`.
         """
+
         def _plot_half_edge(
             self,
             edge: Edge,
@@ -356,8 +356,9 @@ class Planar(Toric, SimPlanar):
         Parameters
         ----------
         args, kwargs
-            Positional and keyword arguments are forwarded to `.unionfind.plot.Toric.Figure2D`. 
+            Positional and keyword arguments are forwarded to `.unionfind.plot.Toric.Figure2D`.
         """
+
         def _plot_ancilla(self, ancilla, **kwargs):
             if type(ancilla) == AncillaQubit:
                 super()._plot_ancilla(ancilla, **kwargs)

--- a/opensurfacesim/decoders/unionfind/sim.py
+++ b/opensurfacesim/decoders/unionfind/sim.py
@@ -510,14 +510,15 @@ class Toric(Sim):
         ancilla
         """
         ancilla.forest = self.code.instance
-        for key in ancilla.parity_qubits:
-            (new_ancilla, edge) = self.get_neighbor(ancilla, key)
+        neighbors = self.get_neighbors(ancilla)
+        for neighbor in neighbors.values():
+            (new_ancilla, edge) = neighbor
             if self.support[edge] == 2:
-                if new_ancilla.forest == self.code.instance and edge.forest != self.code.instance:
-                    self._edge_peel(edge, variant="cycle")
-                else:
+                if new_ancilla.forest != self.code.instance:
                     edge.forest = self.code.instance
                     self.static_forest(new_ancilla)
+                elif new_ancilla.forest == self.code.instance and edge.forest != self.code.instance:
+                    self._edge_peel(edge, variant="cycle")
 
 
 class Planar(Toric):

--- a/opensurfacesim/errors/_template.py
+++ b/opensurfacesim/errors/_template.py
@@ -8,7 +8,7 @@ from functools import wraps
 class Sim(ABC):
     """Template simulation class for errors.
 
-    The template simulation error class can be used as a parent class for error modules for surface code classes that inherit from `.codes._template.sim.PerfectMeasurements` or `.codes._template.sim.FaultyMeasurements`. The error of the module must be applied to each qubit separately using the abstract method `random_error`. 
+    The template simulation error class can be used as a parent class for error modules for surface code classes that inherit from `.codes._template.sim.PerfectMeasurements` or `.codes._template.sim.FaultyMeasurements`. The error of the module must be applied to each qubit separately using the abstract method `random_error`.
 
     Parameters
     ----------
@@ -44,9 +44,9 @@ class Sim(ABC):
 class Plot(Sim):
     """Template plot class for errors.
 
-    The template plotting error class can be used as a parent class for error modules for surface code classes that inherit from `.codes._template.plot.PerfectMeasurements` or `.codes._template.plot.FaultyMeasurements`, which have a figure object attribute at ``code.figure``. The error of the module must be applied to each qubit separately using the abstract method `random_error`. 
+    The template plotting error class can be used as a parent class for error modules for surface code classes that inherit from `.codes._template.plot.PerfectMeasurements` or `.codes._template.plot.FaultyMeasurements`, which have a figure object attribute at ``code.figure``. The error of the module must be applied to each qubit separately using the abstract method `random_error`.
 
-    To change properties of the qubit (a `matplotlib.patches.Circle` object) if an error has been appied to visualize the error. The template plot error class features an easy way to define the plot properties of an error. First of all, each error must be defined in an *error method* that applies the error to the qubit. The template can contain multiple *error methods*, all of which must be called by `random_error`. For all errors that we wish to plot, we must add the names of the methods to ``self.error_methods``. The plot properties are stored under the same name in ``self.plot_params``. 
+    To change properties of the qubit (a `matplotlib.patches.Circle` object) if an error has been appied to visualize the error. The template plot error class features an easy way to define the plot properties of an error. First of all, each error must be defined in an *error method* that applies the error to the qubit. The template can contain multiple *error methods*, all of which must be called by `random_error`. For all errors that we wish to plot, we must add the names of the methods to ``self.error_methods``. The plot properties are stored under the same name in ``self.plot_params``.
 
     .. code-block:: python
 
@@ -60,14 +60,14 @@ class Plot(Sim):
             def random_error(self, qubit):
                 if random.random < 0.5:
                     self.error_method(qubit)
-            
+
             def example_method(self, qubit):
                 # apply error
                 pass
 
     Note that the properties can either be literal or refer to some attribute of the `~.plot.PlotParams` object stored at ``self.code.figure.params`` (see `~.plot.PlotParams.load_params`). Thus the name for the error methods **must be unique** to any attribute in `~plot.PlotParams`.
-    
-    Similarly, additional legend items can be added to the surface code plot ``self.code.figure``. Each legend item is a ``matplotlib.lines.line2D``. The properties for each additional item in the legend is stored at ``self.legend_params``, and must also be unique to any `~.plot.PlotParams` attribute. The legend titles for each item is stored in ``self.legend_titles`` at the same keys. The additional legend items are added in `~.codes._template.PerfectMeasurements.Figure.init_legend`. 
+
+    Similarly, additional legend items can be added to the surface code plot ``self.code.figure``. Each legend item is a ``matplotlib.lines.line2D``. The properties for each additional item in the legend is stored at ``self.legend_params``, and must also be unique to any `~.plot.PlotParams` attribute. The legend titles for each item is stored in ``self.legend_titles`` at the same keys. The additional legend items are added in `~.codes._template.PerfectMeasurements.Figure.init_legend`.
 
     .. code-block:: python
 
@@ -92,12 +92,12 @@ class Plot(Sim):
             def random_error(self, qubit):
                 if random.random < 0.5:
                     self.error_method(qubit)
-            
+
             def example_method(self, qubit):
                 # apply error
                 pass
 
-    Finally, error methods can be also be added to the GUI of the surface code plot. For this, each error method must a *static method* that is not dependant on the error class. Each error method to be added in the GUI must be included in ``self.gui_methods``. The GUI elements are included in `~.codes._template.PerfectMeasurements.Figure.init_plot`. 
+    Finally, error methods can be also be added to the GUI of the surface code plot. For this, each error method must a *static method* that is not dependant on the error class. Each error method to be added in the GUI must be included in ``self.gui_methods``. The GUI elements are included in `~.codes._template.PerfectMeasurements.Figure.init_plot`.
 
     .. code-block:: python
 
@@ -123,7 +123,7 @@ class Plot(Sim):
             def random_error(self, qubit):
                 if random.random < 0.5:
                     self.error_method(qubit)
-            
+
             @staticmethod
             def example_method(qubit):
                 # apply error
@@ -137,25 +137,25 @@ class Plot(Sim):
     Attributes
     ----------
     error_methods : list
-        List of names of the error methods that changes the qubit surface code plot according to properties defined in ``self.plot_params``. 
+        List of names of the error methods that changes the qubit surface code plot according to properties defined in ``self.plot_params``.
     plot_params : {method_name: properties}
-        Qubit plot properties to apply for each of the error methods in ``self.error_methods``. Properties are loaded to the `~.plot.PlotParams` object stored at the ``self.code.figure.params`` attribute of the surface code plot (see `~.plot.PlotParams.load_params`). 
+        Qubit plot properties to apply for each of the error methods in ``self.error_methods``. Properties are loaded to the `~.plot.PlotParams` object stored at the ``self.code.figure.params`` attribute of the surface code plot (see `~.plot.PlotParams.load_params`).
     legend_params {method_name: Line2D properties}
-        Legend items to add to the surface code plot. Properties are loaded to the `~.plot.PlotParams` object stored at the ``self.code.figure.params`` attribute of the surface code plot (see `~.plot.PlotParams.load_params`), and used to initialize a `~matplotlib.lines.Line2D` legend item. 
+        Legend items to add to the surface code plot. Properties are loaded to the `~.plot.PlotParams` object stored at the ``self.code.figure.params`` attribute of the surface code plot (see `~.plot.PlotParams.load_params`), and used to initialize a `~matplotlib.lines.Line2D` legend item.
     legend_titles : {method_name: legend_title}
         Titles to display for the legend items in ``self.legend_params``.
     gui_permanent : bool
         If enabled, the application of an error method on a qubit cannot be reversed within the same simulation instance.
     gui_methods : list
-        List of names of the static error methods include in the surface plot GUI. 
+        List of names of the static error methods include in the surface plot GUI.
     """
+
     error_methods: list = []
     legend_params: dict = {}
     legend_titles: dict = {}
     plot_params: dict = {}
     gui_permanent: bool = False
     gui_methods: list = []
-    
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, *kwargs)
@@ -168,14 +168,14 @@ class Plot(Sim):
             setattr(self, error_name, self.plot_error(error_name))
 
     def plot_error(self, error_name):
-        """Decorates the error method with plotting features. 
+        """Decorates the error method with plotting features.
 
-        The method ``error_name`` is decorated with plot property changes defined in ``self.plot_params``. For each of the properties to change, the original property value of the artist is stored and requested as a change at the end of the simulation instance. 
+        The method ``error_name`` is decorated with plot property changes defined in ``self.plot_params``. For each of the properties to change, the original property value of the artist is stored and requested as a change at the end of the simulation instance.
 
         See Also
         --------
         `.plot.Template2D.temporary_properties`
-        `.plot.Template2D.new_properties`. 
+        `.plot.Template2D.new_properties`.
         """
         sim_method = getattr(self, error_name)
         figure = self.code.figure

--- a/opensurfacesim/errors/erasure.py
+++ b/opensurfacesim/errors/erasure.py
@@ -12,7 +12,7 @@ class Sim(TemplateSim):
     p_erasure
         Default probability of erasure errors.
     initial_states
-        Default state of the qubit after re-initialization. 
+        Default state of the qubit after re-initialization.
     """
 
     def __init__(self, *args, p_erasure: float = 0, initial_states: Tuple[float, float] = (0, 0), **kwargs):
@@ -33,7 +33,7 @@ class Sim(TemplateSim):
         p_erasure
             Overriding probability of erasure errors.
         initial_states
-            Overriding state of the qubit after re-initialization. 
+            Overriding state of the qubit after re-initialization.
         """
         if p_erasure is None:
             p_erasure = self.default_error_rates["p_erasure"]
@@ -45,13 +45,13 @@ class Sim(TemplateSim):
     @staticmethod
     def erasure(qubit: DataQubit, instance: float = 0, initial_states: Tuple[float, float] = (0, 0), **kwargs):
         """Erases the ``qubit`` by resetting its attributes.
-        
+
         Parameters
         ----------
         qubit
-            Qubit to erase. 
+            Qubit to erase.
         instance
-            Current simulation instance. 
+            Current simulation instance.
         initial_states
             State of the qubit after re-initialization.
         """

--- a/opensurfacesim/main.py
+++ b/opensurfacesim/main.py
@@ -33,7 +33,7 @@ def initialize(
 ):
     """Initializes a code and a decoder.
 
-    The function makes sure that the correct class is used to instance the surface code and decoder based on the arguments provided. A code instance must be initalized with ``enabled_errors`` by `~codes._template.sim.initialize` after class instance to make sure that plot parameters are properly loaded before loading the plotting items included in each included error module, if ``plotting`` is enabled. See `.plot.Template2D` and `.errors._template.Plot` for more information. 
+    The function makes sure that the correct class is used to instance the surface code and decoder based on the arguments provided. A code instance must be initalized with ``enabled_errors`` by `~codes._template.sim.initialize` after class instance to make sure that plot parameters are properly loaded before loading the plotting items included in each included error module, if ``plotting`` is enabled. See `.plot.Template2D` and `.errors._template.Plot` for more information.
 
     Parameters
     ----------
@@ -60,7 +60,7 @@ def initialize(
         (<toric (6, 6) PerfectMeasurements>,  <Minimum-Weight Perfect Matching decoder (Toric)>)
         ✅ This decoder is compatible with the code.
 
-    Keyword arguments for the code and decoder classes can be included for further customization of class initialization. Note that default errors rates for error class initialization (see `~.codes._template.sim.PerfectMeasurements.init_errors` and `.errors._template.Sim`) can also be provided as keyword arguments here. 
+    Keyword arguments for the code and decoder classes can be included for further customization of class initialization. Note that default errors rates for error class initialization (see `~.codes._template.sim.PerfectMeasurements.init_errors` and `.errors._template.Sim`) can also be provided as keyword arguments here.
 
         >>> enabled_errors = ["pauli"]
         >>> code_kwargs = {
@@ -121,7 +121,7 @@ def run(
     error_rates
         Dictionary of error rates (see `~opensurfacesim.errors`). Errors must have been loaded during code class initialization by `~.codes._template.sim.PerfectMeasurements.initialize` or `~.codes._template.sim.PerfectMeasurements.init_errors`.
     decode_initial
-        Decode initial code configuration before applying loaded errors. If random states are used for the data-qubits of the ``code`` at class initialization (default behavior), an initial round of decoding is required and is enabled through the ``decode_initial`` flag (default is enabled).  
+        Decode initial code configuration before applying loaded errors. If random states are used for the data-qubits of the ``code`` at class initialization (default behavior), an initial round of decoding is required and is enabled through the ``decode_initial`` flag (default is enabled).
     seed
         Float to use as the seed for the random number generator.
     benchmark
@@ -157,7 +157,7 @@ def run(
 
     if decode_initial:
         code.random_errors()
-        decoder.decode(**kwargs)    
+        decoder.decode(**kwargs)
         code.logical_state
 
     if benchmark:
@@ -169,7 +169,7 @@ def run(
         print(f"Running iteration {iteration+1}/{iterations}", end="\r")
         code.random_errors(**error_rates)
         decoder.decode(**kwargs)
-        code.logical_state          # Must get logical state property to update code.no_error
+        code.logical_state  # Must get logical state property to update code.no_error
         output["no_error"] += code.no_error
         if hasattr(code, "figure"):
             code.show_corrected()
@@ -221,7 +221,7 @@ def run_multiprocess(
     iterations
         Total number of iterations to run.
     decode_initial
-        Decode initial code configuration before applying loaded errors. 
+        Decode initial code configuration before applying loaded errors.
     seed
         Float to use as the seed for the random number generator.
     processes
@@ -243,7 +243,7 @@ def run_multiprocess(
 
     if decode_initial:
         code.random_errors()
-        decoder.decode(**kwargs)    
+        decoder.decode(**kwargs)
         code.logical_state
 
     # Initiate processes

--- a/opensurfacesim/plot.py
+++ b/opensurfacesim/plot.py
@@ -355,13 +355,13 @@ class Template2D(ABC):
         
         If the Tkinter backend is enabled or can be enabled, the function returns True. For other backends False is returned. 
         """
-        backend = mpl.get_backend()
-        if backend == "TkAgg":
+        backend = mpl.get_backend().lower()
+        if backend in ["tkagg", "qt5agg"]:
             return True
         elif "inline" in backend:
             from IPython.display import display
             self.display = display
-        elif backend == "agg":
+        else:
             try:
                 DISPLAY = os.environ.get("DISPLAY", None)
                 if DISPLAY:
@@ -370,9 +370,7 @@ class Template2D(ABC):
                 else:
                     raise ImportError(f"Display at {DISPLAY} not available.")
             except ImportError:
-                print(f"Plotting is not available for Agg backend. TkAgg backend could not be loaded.")
-        else:
-            print(f"Matplotlib is using {backend} backend. Interactive plotting is disabled.")
+                print(f"Matplotlib is using {backend} backend, which is not supported. ")
         return False
 
 

--- a/opensurfacesim/plot.py
+++ b/opensurfacesim/plot.py
@@ -26,11 +26,10 @@ class PlotParams:
 
     Examples
     --------
-    See the below example where the background color of the figure is changed to black. Note that we first have to inherited from the `.Template2D` class and supply a `~.Template2D.init_plot` method for it to be able to be instanced.
+    See the below example where the background color of the figure is changed to black. Note that we have to inherit from the `.Template2D` class.
 
         >>> class Plotting(Template2D):
-        ...     def init_plot():
-        ...         pass
+        ...     pass
         >>> custom_params = PlotParams(color_background = (0,0,0,1))
         >>> plot_with_custom_params = Plotting(plot_params=custom_params)
     """
@@ -170,7 +169,7 @@ class Template2D(ABC):
     - Keyboard navigation for iteration selection.
     - Plot object information by picking.
 
-    To instance this class, one must inherit the current class and supply a :meth:`init_plot` method that draws the objects of the plot. The existing objects can then be altered by updating their plot properties by :meth:`new_properties`, where the changed properties must be a dictionary with keywords and values corresponding tho the respective matplotlib object. Every change in plot property is stored in ``self.history_dict``. This allows to undo or redo changes by simply applying the saved changed properties in the dictionary. Fast plotting is enabled by not drawing the figure after every queued change. Instead, each object is draw in the canvas individually after a property change and a series of changes is drawn to the figure when a new plot iteration is requested via :meth:`new_iter`. This is performed by *blitting* the canvas.
+    To instance this class, one must inherit the current class. The existing objects can then be altered by updating their plot properties by :meth:`new_properties`, where the changed properties must be a dictionary with keywords and values corresponding tho the respective matplotlib object. Every change in plot property is stored in ``self.history_dict``. This allows to undo or redo changes by simply applying the saved changed properties in the dictionary. Fast plotting is enabled by not drawing the figure after every queued change. Instead, each object is draw in the canvas individually after a property change and a series of changes is drawn to the figure when a new plot iteration is requested via :meth:`new_iter`. This is performed by *blitting* the canvas.
 
     Keyboard navigation and picking is enabled by blocking the code via a custom `.BlockingKeyInput` class. While the code is blocked, inputs are caught by the blocking class and processed for history navigation or picking navigation. Moving the iteration past the available history allows for the code to continue. The keyboard input is parsed by :meth:`focus`.
 
@@ -186,7 +185,7 @@ class Template2D(ABC):
     figure : `matplotlib.figure.Figure`
         Main figure.
     interactive : bool
-       Enables GUI elements and interactive plotting. 
+       Enables GUI elements and interactive plotting.
     main_ax : `matplotlib.axes.Axes`
         Main axis of the figure.
     history_dict : `.collections.defaultdict`
@@ -242,7 +241,8 @@ class Template2D(ABC):
 
         >>> import matplotlib.pyplot as plt
         ... class Example(Template2D):
-        ...     def init_plot(self):
+        ...     def __init__(self, *args, **kwargs):
+        ...         super().__init__(*args, **kwargs)
         ...         self.line = plt.plot(0, 0, color="k", ls="-")[0]    # Line located at [0] after plot
         >>> fig = Example()
         >>> fig.new_properties(fig.line, {"color": "r})
@@ -286,12 +286,13 @@ class Template2D(ABC):
 
     The ``history_dict`` for a plot with a Line2D object and a Circle object. In the second iteration, the color of the Line2D object is updated from black to red, and the linestyle of the Circle object is changed from "-" to ":".
     """
+
     def __init__(
         self,
         plot_params: Optional[PlotParams] = None,
         projection: Optional[str] = None,
         **kwargs,
-    ):  
+    ):
         self.interactive = self.load_interactive_backend()
         self.projection = projection
         self.params = plot_params if plot_params else PlotParams()
@@ -349,17 +350,17 @@ class Template2D(ABC):
         if self.interactive:
             self.canvas.draw()
 
-
     def load_interactive_backend(self) -> bool:
         """Configures the plotting backend.
-        
-        If the Tkinter backend is enabled or can be enabled, the function returns True. For other backends False is returned. 
+
+        If the Tkinter backend is enabled or can be enabled, the function returns True. For other backends False is returned.
         """
         backend = mpl.get_backend().lower()
         if backend in ["tkagg", "qt5agg"]:
             return True
         elif "inline" in backend:
             from IPython.display import display
+
             self.display = display
         else:
             DISPLAY = os.environ.get("DISPLAY", None)
@@ -369,7 +370,7 @@ class Template2D(ABC):
                     return True
                 except ImportError:
                     pass
-                try: 
+                try:
                     mpl.use("Qt5Agg")
                     return True
                 except ImportError:
@@ -379,7 +380,6 @@ class Template2D(ABC):
             else:
                 print(f"Display {DISPLAY} not available. Interactive plotting is disabled.")
         return False
-
 
     def close(self):
         """Closes the figure."""
@@ -396,11 +396,6 @@ class Template2D(ABC):
                                     Initialization
     -------------------------------------------------------------------------------
     """
-
-    @abstractmethod
-    def init_plot(self, **kwargs):
-        """Initializes the figure by plotting al main and recurring objects"""
-        pass
 
     def _init_axis(
         self,
@@ -468,7 +463,7 @@ class Template2D(ABC):
 
         When the method is active, the focus is on the figure. This will be indicated by a green circle in the bottom right of the figure. When the focus is lost, the code execution is continued and the icon is red. The change is icon color is performed by :meth:`_set_figure_state`, which also hides the interactive elements when the focus is lost.
         """
-        self.canvas.draw() 
+        self.canvas.draw()
         wait = True
         while wait:
             self._set_figure_state("g")
@@ -543,7 +538,7 @@ class Template2D(ABC):
         self.block_icon.set_color(color)
         self.block_box.draw_artist(self.block_icon)
         self.canvas.blit(self.block_box.bbox)
-        self.canvas.draw() 
+        self.canvas.draw()
 
     """
     -------------------------------------------------------------------------------
@@ -638,7 +633,7 @@ class Template2D(ABC):
             else:
                 print(f"Cannot add iteration {new_iter_name} to history, currently not on most recent iteration.")
         if not (new_iter_name and self.history_at_newest):
-            new_iter_name = self.history_iter_names[self.history_iter-1]
+            new_iter_name = self.history_iter_names[self.history_iter - 1]
         text = "{}/{}: {}".format(self.history_iter, self.history_iters, new_iter_name)
         self.text.set_text(text)
 
@@ -653,7 +648,6 @@ class Template2D(ABC):
             self.focus()
         else:
             self.display(self.figure)
-
 
     def _draw_from_history(self, condition: bool, direction: int, draw: bool = True, **kwargs) -> bool:
         """Move a single plot iteration forward or backwards.

--- a/opensurfacesim/threshold.py
+++ b/opensurfacesim/threshold.py
@@ -64,7 +64,7 @@ def run_many(
 
     Examples
     --------
-    A series of simulations using the ``toric`` surface code and ``mwpm`` decoder can be easily setup. Benchmarking can be performed by supplying the ``methods_to_benchmark`` argument of the `~.main.BenchmarkDecoder` class. The function will initialize a benchmark object of each configuration and append all results as columns to the returned dataframe. 
+    A series of simulations using the ``toric`` surface code and ``mwpm`` decoder can be easily setup. Benchmarking can be performed by supplying the ``methods_to_benchmark`` argument of the `~.main.BenchmarkDecoder` class. The function will initialize a benchmark object of each configuration and append all results as columns to the returned dataframe.
 
         >>> data = run_many(
         ...     "toric",
@@ -75,18 +75,18 @@ def run_many(
         ...     error_rates = [{"p_bitflip: p} for p in [0.09, 0.1, 0.11]],
         ... )
         >>> print(data)
-                        datetime  decoded    iterations  no_error  p_bitflip          seed  size  
-        0   04/11/2020 14:45:36   1000.0        1000.0     820.0       0.09  13163.013981   8.0  
-        1   04/11/2020 14:45:45   1000.0        1000.0     743.0       0.10  13172.277886   8.0  
-        2   04/11/2020 14:45:54   1000.0        1000.0     673.0       0.11  13181.090130   8.0  
-        3   04/11/2020 14:46:36   1000.0        1000.0     812.0       0.09  13190.191461  12.0  
-        4   04/11/2020 14:47:18   1000.0        1000.0     768.0       0.10  13232.408302  12.0  
-        5   04/11/2020 14:48:16   1000.0        1000.0     629.0       0.11  13274.044268  12.0  
-        6   04/11/2020 14:51:47   1000.0        1000.0     855.0       0.09  13332.153639  16.0  
-        7   04/11/2020 14:55:15   1000.0        1000.0     754.0       0.10  13542.533067  16.0  
+                        datetime  decoded    iterations  no_error  p_bitflip          seed  size
+        0   04/11/2020 14:45:36   1000.0        1000.0     820.0       0.09  13163.013981   8.0
+        1   04/11/2020 14:45:45   1000.0        1000.0     743.0       0.10  13172.277886   8.0
+        2   04/11/2020 14:45:54   1000.0        1000.0     673.0       0.11  13181.090130   8.0
+        3   04/11/2020 14:46:36   1000.0        1000.0     812.0       0.09  13190.191461  12.0
+        4   04/11/2020 14:47:18   1000.0        1000.0     768.0       0.10  13232.408302  12.0
+        5   04/11/2020 14:48:16   1000.0        1000.0     629.0       0.11  13274.044268  12.0
+        6   04/11/2020 14:51:47   1000.0        1000.0     855.0       0.09  13332.153639  16.0
+        7   04/11/2020 14:55:15   1000.0        1000.0     754.0       0.10  13542.533067  16.0
         8   04/11/2020 14:59:14   1000.0        1000.0     621.0       0.11  13751.082511  16.0
 
-    
+
 
 
     """
@@ -160,11 +160,11 @@ def read_csv(file: str) -> pd.DataFrame:
 @dataclass
 class ThresholdFit:
     """Fitter for code threshold with data obtained by ``~.threshold.run``.
-    
-    Threshold fitting is performed using the equations described in [wang2003confinement]_. The threshold is computing the ground state of the Hamiltonian that described the phase transition or the Nishimori line in the Random Bond Ising Model. The source provides two functions which are included in this fitting class, where the ``modified_ansatz`` includes a nonuniversion additive correction to correct for finite size effects. 
 
-    .. [wang2003confinement] Chenyang Wang, Jim Harrington and John Preskill, *Confinement-Higgs transition in a disordered gauge theory and the accuracy threshold for quantum memory*, Annals of Physics, 1:31-58, 2003. 
-    
+    Threshold fitting is performed using the equations described in [wang2003confinement]_. The threshold is computing the ground state of the Hamiltonian that described the phase transition or the Nishimori line in the Random Bond Ising Model. The source provides two functions which are included in this fitting class, where the ``modified_ansatz`` includes a nonuniversion additive correction to correct for finite size effects.
+
+    .. [wang2003confinement] Chenyang Wang, Jim Harrington and John Preskill, *Confinement-Higgs transition in a disordered gauge theory and the accuracy threshold for quantum memory*, Annals of Physics, 1:31-58, 2003.
+
     """
 
     modified_ansatz: bool = False

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/watermarkhu/opensurfacesim",
-    project_urls={
-        "Documentation": "https://opensurfacesim.readthedocs.io/en/latest/"
-    },
+    project_urls={"Documentation": "https://opensurfacesim.readthedocs.io/en/latest/"},
     author="Mark Shui Hu",
     author_email="watermarkhu@gmail.com",
     license="BSD-3",
@@ -26,9 +24,9 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    packages=find_packages(exclude=['tests', '*.tests', '*.tests.*']),
-    include_package_data = True,
-    python_requires='>3.7.0',
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
+    include_package_data=True,
+    python_requires=">3.7.0",
     install_requires=[
         "matplotlib>=3.3.2",
         "networkx>=2.0",
@@ -37,7 +35,7 @@ setup(
         "pptree>=3.1",
     ],
     entry_points={
-        "console_scrips":[
+        "console_scrips": [
             "py-opensurfacesim=opensurfacesim.__main__:main",
             "opensurfacesim-getblossomv=opensurfacesim.decoders.mwpm:get_blossomv",
         ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,7 @@
 from opensurfacesim.__main__ import cli
-import opensurfacesim as oss
 import pytest
+from .variables import *
 
-
-CODES = oss.codes.CODES
-DECODERS = oss.decoders.DECODERS
-ERRORS = oss.errors.ERRORS
-SIZE_PM = 8
-SIZE_FM = 3
 ITERS = [1, 10]
 PROCESSES = [1, 2]
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,11 +1,8 @@
 from opensurfacesim import codes
-import opensurfacesim as oss
 import pytest
+from .variables import *
 
-
-CODES = codes.CODES
 code_types = ["PerfectMeasurements", "FaultyMeasurements"]
-no_wait_param = oss.plot.PlotParams(blocking_wait=0.001)
 
 
 @pytest.mark.plotting

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,7 @@
 from opensurfacesim.main import *
-import opensurfacesim as oss
 import pytest
+from .variables import *
 
-
-CODES = oss.codes.CODES
-DECODERS = oss.decoders.DECODERS
-ERRORS = oss.errors.ERRORS
-no_wait_param = oss.plot.PlotParams(blocking_wait=0.001)
-SIZE_PM = 8
-SIZE_FM = 3
 SEED = 12345
 ITERS = [1, 10]
 MP_ITERS = 24
@@ -27,6 +20,7 @@ MP_ITERS = 24
 def test_initialize(size, Code, Decoder, error, faulty):
     """Test initialize function for all configurations."""
     initialize(size, Code, Decoder, enabled_errors=[error], faulty_measurements=faulty)
+
 
 @pytest.mark.plotting
 @pytest.mark.parametrize("Code", CODES)
@@ -54,10 +48,11 @@ def test_initialize_plot(size, Code, faulty, figure3d):
 
 
 @pytest.mark.parametrize("iterations", ITERS)
-def test_run(iterations):
+@pytest.mark.parametrize("initial_states, decode_initial", [((0, 0), False), ((None, None), True)])
+def test_run(iterations, initial_states, decode_initial):
     """Test run function for single and multiple iterations."""
-    code, decoder = initialize(SIZE_PM, CODES[0], DECODERS[0])
-    output = run(code, decoder, iterations=iterations)
+    code, decoder = initialize(SIZE_PM, CODES[0], DECODERS[0], initial_states=initial_states)
+    output = run(code, decoder, iterations=iterations, decode_initial=decode_initial)
     asserted_output = {"no_error": iterations}
     assert output == asserted_output
 

--- a/tests/test_mplbackends.py
+++ b/tests/test_mplbackends.py
@@ -1,0 +1,33 @@
+from opensurfacesim.main import *
+import matplotlib as mpl
+import pytest
+from .variables import *
+
+
+backends = ["TkAgg", "Qt5Agg"]
+
+
+@pytest.mark.plotting
+@pytest.mark.parametrize(
+    "faulty, figure3d, size",
+    [
+        (False, False, SIZE_PM),
+        (True, False, SIZE_FM),
+        (True, True, SIZE_FM),
+    ],
+)
+@pytest.mark.parametrize("backend", backends)
+def test_initialize_plot(size, faulty, figure3d, backend):
+    """Test all code figures configurations."""
+    mpl.use(backend)
+    code, decoder = initialize(
+        size,
+        CODES[0],
+        DECODERS[0],
+        enabled_errors=ERRORS,
+        faulty_measurements=faulty,
+        plotting=True,
+        plot_params=no_wait_param,
+        figure3d=figure3d,
+    )
+    code.figure.close()

--- a/tests/test_mwpm.py
+++ b/tests/test_mwpm.py
@@ -2,13 +2,9 @@ from opensurfacesim.main import *
 import opensurfacesim as oss
 import pytest
 import random
-from .errors import get_error_combinations, get_error_keys
+from .variables import *
 
 
-CODES = oss.codes.CODES
-ERRORS = oss.errors.ERRORS
-SIZE_PM = 12
-SIZE_FM = 4
 ITERS = 100
 
 

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -3,10 +3,7 @@ import opensurfacesim as oss
 import pytest
 import pandas as pd
 import matplotlib.pyplot as plt
-
-
-CODES = oss.codes.CODES
-DECODERS = oss.decoders.DECODERS
+from .variables import *
 
 
 @pytest.fixture

--- a/tests/test_ufns.py
+++ b/tests/test_ufns.py
@@ -1,13 +1,10 @@
 from opensurfacesim.main import *
 import opensurfacesim as oss
+import matplotlib as mpl
 import pytest
 import random
-from .errors import get_error_combinations, get_error_keys
+from .variables import *
 
-
-CODES = oss.codes.CODES
-SIZE_PM = 12
-SIZE_FM = 4
 ITERS = 100
 no_wait_param = oss.plot.PlotParams(blocking_wait=0.001)
 
@@ -61,19 +58,14 @@ def test_ufns_plot(faulty, size):
         "toric",
         "ufns",
         enabled_errors=["pauli"],
+        faulty_measurements=faulty,
+        initial_states=(0, 0),
         plotting=True,
         plot_params=no_wait_param,
-        faulty_measurements=faulty,
-    )
-    run(
-        code,
-        decoder,
-        error_rates={"p_bitflip": 0.1},
-        print_steps=True,
-        print_tree=True,
         step_bucket=True,
         step_cluster=True,
         step_node=True,
         step_cycle=True,
         step_peel=True,
     )
+    run(code, decoder, error_rates={"p_bitflip": 0.1}, decode_initial=False)

--- a/tests/test_unionfind.py
+++ b/tests/test_unionfind.py
@@ -2,15 +2,10 @@ from opensurfacesim.main import *
 import opensurfacesim as oss
 import pytest
 import random
-from .errors import get_error_combinations, get_error_keys
+from .variables import *
 
 
-CODES = oss.codes.CODES
-ERRORS = oss.errors.ERRORS
-SIZE_PM = 12
-SIZE_FM = 4
 ITERS = 100
-no_wait_param = oss.plot.PlotParams(blocking_wait=0.001)
 
 
 @pytest.mark.parametrize("Code", CODES)
@@ -52,15 +47,19 @@ def test_unionfind_sim(size, Code, errors, faulty, max_rate, extra_keys):
 @pytest.mark.parametrize("dynamic_forest", [False, True])
 def test_unionfind_options(weighted_growth, weighted_union, dynamic_forest):
     """Test options of unionfind decoder."""
-    code, decoder = initialize(SIZE_PM, "toric", "unionfind", enabled_errors=["pauli"])
+    code, decoder = initialize(
+        SIZE_PM,
+        "toric",
+        "unionfind",
+        enabled_errors=["pauli"],
+        weighted_growth=weighted_growth,
+        weighted_union=weighted_union,
+        dynamic_forest=dynamic_forest,
+    )
     trivial = 0
     for _ in range(ITERS):
         code.random_errors(p_bitflip=random.random() * 0.2)
-        decoder.decode(
-            weighted_growth=weighted_growth,
-            weighted_union=weighted_union,
-            dynamic_forest=dynamic_forest,
-        )
+        decoder.decode()
         trivial += code.trivial_ancillas
 
     assert trivial == ITERS
@@ -80,17 +79,13 @@ def test_unionfind_plot(faulty, size):
         "toric",
         "unionfind",
         enabled_errors=["pauli"],
+        faulty_measurements=faulty,
+        initial_states=(0, 0),
         plotting=True,
         plot_params=no_wait_param,
-        faulty_measurements=faulty,
-    )
-    run(
-        code,
-        decoder,
-        error_rates={"p_bitflip": 0.1},
-        print_steps=True,
         step_bucket=True,
         step_cluster=True,
         step_cycle=True,
         step_peel=True,
     )
+    run(code, decoder, error_rates={"p_bitflip": 0.1}, decode_initial=False)

--- a/tests/variables.py
+++ b/tests/variables.py
@@ -2,7 +2,12 @@ import opensurfacesim as oss
 from opensurfacesim.codes.toric.sim import PerfectMeasurements as toric_code
 import itertools
 
+CODES = oss.codes.CODES
+DECODERS = oss.decoders.DECODERS
 ERRORS = oss.errors.ERRORS
+no_wait_param = oss.plot.PlotParams(blocking_wait=0.1)
+SIZE_PM = 9
+SIZE_FM = 3
 
 
 def get_error_combinations():


### PR DESCRIPTION
Interactive plotting using the Qt5Agg backend, which can be forced by

```python
import matplotlib
matplotlib.use("Qt5Agg")
```

The Qt5Aagg backend is mostly compatible with current implementation for interactive plotting using the Tkinter backend. However, there are some bugs to fix. 

- [x] Update figure after pick event
- [x] Redrawing past iterations from `self.history_dict`

Resolves #32 